### PR TITLE
カテゴリ画像を動的にAPIの値を利用するように修正

### DIFF
--- a/app/ejs/mypage.ejs
+++ b/app/ejs/mypage.ejs
@@ -143,7 +143,7 @@
             '<div class="vo-card">'+
               '<a href="mypage-detail.html?category='+categories[i]['id']+'">'+
                 '<div class="vo-card__image">'+
-                  '<img src="./assets/img/pizza.png">'+
+                  '<img src="https://kensyu.jeez.jp'+categories[i]['image']+'">'+
                 '</div>'+
                 '<div class="vo-card__title">'+
                   '<p>'+categories[i]['name']+'</p>'+

--- a/app/mypage.html
+++ b/app/mypage.html
@@ -217,7 +217,7 @@
             '<div class="vo-card">'+
               '<a href="mypage-detail.html?category='+categories[i]['id']+'">'+
                 '<div class="vo-card__image">'+
-                  '<img src="./assets/img/pizza.png">'+
+                  '<img src="https://kensyu.jeez.jp'+categories[i]['image']+'">'+
                 '</div>'+
                 '<div class="vo-card__title">'+
                   '<p>'+categories[i]['name']+'</p>'+


### PR DESCRIPTION
カテゴリの画像をAPI経由で返すようにしたので、そちらを利用するように修正

画像をサーバーに保存してそこを参照するパスを返しているが、これdriveのURL返すとかだと運用的に楽なのかなって思ったり思わなかったりしてる。
https://qiita.com/codeDiver/items/0394968fa318d9309d33

ただ、なんかiPhoneで表示できない画像が云々という記事も見かけたのでおとなしく保存するか、カテゴリ画像登録用フォームみたいなのつくるのもありなのかなと思ったりもしました。